### PR TITLE
Multi NIC Partial Phase Support

### DIFF
--- a/pkg/apis/vspherecapacitymanager.splat.io/v1/vars.go
+++ b/pkg/apis/vspherecapacitymanager.splat.io/v1/vars.go
@@ -5,6 +5,7 @@ const (
 	RESOURCE_ALLOCATION_STRATEGY_UNDERUTILIZED = AllocationStrategy("under-utilized")
 
 	PHASE_FULFILLED Phase = "Fulfilled"
+	PHASE_PARTIAL   Phase = "Partial"
 	PHASE_PENDING   Phase = "Pending"
 	PHASE_FAILED    Phase = "Failed"
 )

--- a/pkg/utils/pools.go
+++ b/pkg/utils/pools.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"math/rand"
 	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1"
 )

--- a/plugin/oc-vcm
+++ b/plugin/oc-vcm
@@ -78,6 +78,8 @@ def getLeaseStatus():
     multiTenant = 0
     singleTenantPending = 0
     multiTenantPending = 0
+    singleTenantPartial = 0
+    multiTenantPartial = 0
     count = 0
     pending = 0
     leases = getLeases()
@@ -87,12 +89,16 @@ def getLeaseStatus():
             multiTenant += 1
             if lease["status"]["phase"] == "Pending":
                 multiTenantPending += 1
+            if lease["status"]["phase"] == "Partial":
+                multiTenantPartial += 1
         else:
             singleTenant += 1
             if lease["status"]["phase"] == "Pending":
-                singleTenantPending += 1            
+                singleTenantPending += 1
+            if lease["status"]["phase"] == "Partial":
+                singleTenantPartial += 1
         
-    return count, pending, singleTenant, multiTenant, singleTenantPending, multiTenantPending
+    return count, pending, singleTenant, multiTenant, singleTenantPending, multiTenantPending, singleTenantPartial, multiTenantPartial
 
 def printStatus():
     singleTenantCount, multiTenantCount = getNetworkCounts()
@@ -119,10 +125,11 @@ def printStatus():
         print("| ".ljust(nameMaxLen) + "| " + networkUsage.ljust(usageLen-2) + "| ".ljust(cordonLen-1) + "  | ".ljust(excludedLen) + "   |")
         print(header)        
 
-    leaseCount, pendingLeases, singleTenantUsage, multiTenantUsage, singleTenantPending, multiTenantPending = getLeaseStatus()
+    leaseCount, pendingLeases, singleTenantUsage, multiTenantUsage, singleTenantPending, multiTenantPending, singleTenantPartial, multiTenantPartial = getLeaseStatus()
 
     print("\nLease Count: " + str(leaseCount) + ", single-tenant usage: " + str(format(singleTenantUsage / singleTenantCount, ".0%")) + ", multi-tenant usage: " + str(format(multiTenantUsage / multiTenantCount, ".0%")))
     print("Pending Leases: " + str(pendingLeases) + ", pending single-tenant: " + str(singleTenantPending) + ", pending multi-tenant: " + str(multiTenantPending))
+    print("Partial Leases: " + str(singleTenantPartial + multiTenantPartial) + ", partial single-tenant: " + str(singleTenantPartial) + ", partial multi-tenant: " + str(multiTenantPartial))
 
 def dropPortGroupFromPools(portGroup, poolName):
     if poolName == "":


### PR DESCRIPTION
This PR add the new ability to have partial leases.  This means that when a lease requests multiple networks, but only 1 is available, the available networks will be assigned and the lease will be put into a new Partial phase state.  It will stay here until the remaining networks become available.  

This feature is required to prevent starvation when the build cluster is busy.  When there are no networks, and there are multiple pending, the leases w/ single network requests will always get fulfilled before the multi network which may lead the multi network jobs to be started and timed out.