### PR TITLE
Prevent multi network leases from having duplicate port groups

### DIFF
--- a/test/manifests/network-ci-vlan-938-1-dal10-dal10.pod03-multi-1.yaml
+++ b/test/manifests/network-ci-vlan-938-1-dal10-dal10.pod03-multi-1.yaml
@@ -1,0 +1,28 @@
+apiVersion: vspherecapacitymanager.splat.io/v1
+kind: Network
+metadata:
+  labels:
+    vsphere-capacity-manager.splat-team.io/network-type: multi-tenant
+  name: ci-vlan-938-1-dal10-dal10.pod03-multi-1
+spec:
+  cidr: 25
+  cidrIPv6: 64
+  datacenterName: dal10
+  gateway: 10.93.251.1
+  gatewayipv6: fd65:a1a8:60ad:938::2
+  ipAddressCount: 128
+  ipAddresses:
+    - 10.93.251.2
+    - 10.93.251.3
+    - 10.93.251.4
+    - 10.93.251.5
+  ipv6prefix: fd65:a1a8:60ad:938::/64
+  machineNetworkCidr: 10.93.251.0/25
+  netmask: 255.255.255.128
+  podName: dal10.pod03
+  portGroupName: ci-vlan-938-1
+  primaryRouterHostname: bcr03a.dal10
+  startIPv6Address: fd65:a1a8:60ad:938::4
+  subnetType: SECONDARY_ON_VLAN
+  vlanId: "938"
+

--- a/test/manifests/network-ci-vlan-938-1-dal10-dal10.pod03-multi-2.yaml
+++ b/test/manifests/network-ci-vlan-938-1-dal10-dal10.pod03-multi-2.yaml
@@ -1,0 +1,28 @@
+apiVersion: vspherecapacitymanager.splat.io/v1
+kind: Network
+metadata:
+  labels:
+    vsphere-capacity-manager.splat-team.io/network-type: multi-tenant
+  name: ci-vlan-938-1-dal10-dal10.pod03-multi-2
+spec:
+  cidr: 25
+  cidrIPv6: 64
+  datacenterName: dal10
+  gateway: 10.93.251.1
+  gatewayipv6: fd65:a1a8:60ad:938::2
+  ipAddressCount: 128
+  ipAddresses:
+    - 10.93.251.4
+    - 10.93.251.5
+    - 10.93.251.6
+    - 10.93.251.7
+  ipv6prefix: fd65:a1a8:60ad:938::/64
+  machineNetworkCidr: 10.93.251.0/25
+  netmask: 255.255.255.128
+  podName: dal10.pod03
+  portGroupName: ci-vlan-938-2
+  primaryRouterHostname: bcr03a.dal10
+  startIPv6Address: fd65:a1a8:60ad:938::4
+  subnetType: SECONDARY_ON_VLAN
+  vlanId: "938"
+

--- a/test/manifests/network-ci-vlan-938-1-dal10-dal10.pod03-multi-3.yaml
+++ b/test/manifests/network-ci-vlan-938-1-dal10-dal10.pod03-multi-3.yaml
@@ -1,0 +1,30 @@
+apiVersion: vspherecapacitymanager.splat.io/v1
+kind: Network
+metadata:
+  labels:
+    vsphere-capacity-manager.splat-team.io/network-type: multi-tenant
+  name: ci-vlan-938-1-dal10-dal10.pod03-multi-3
+spec:
+  cidr: 25
+  cidrIPv6: 64
+  datacenterName: dal10
+  gateway: 10.93.251.1
+  gatewayipv6: fd65:a1a8:60ad:938::2
+  ipAddressCount: 128
+  ipAddresses:
+    - 10.93.251.6
+    - 10.93.251.7
+    - 10.93.251.8
+    - 10.93.251.9
+  ipv6prefix: fd65:a1a8:60ad:938::/64
+  machineNetworkCidr: 10.93.251.0/25
+  netmask: 255.255.255.128
+  podName: dal10.pod03
+  portGroupName: ci-vlan-938-3
+  primaryRouterHostname: bcr03a.dal10
+  startIPv6Address: fd65:a1a8:60ad:938::4
+  subnetType: SECONDARY_ON_VLAN
+  vlanId: "938"
+
+
+

--- a/test/manifests/network-ci-vlan-938-1-dal10-dal10.pod03.yaml
+++ b/test/manifests/network-ci-vlan-938-1-dal10-dal10.pod03.yaml
@@ -1,0 +1,43 @@
+apiVersion: vspherecapacitymanager.splat.io/v1
+kind: Network
+metadata:
+  labels:
+    vsphere-capacity-manager.splat-team.io/network-type: multi-tenant
+  name: ci-vlan-938-1-dal10-dal10.pod03
+spec:
+  cidr: 25
+  cidrIPv6: 64
+  datacenterName: dal10
+  gateway: 10.93.251.1
+  gatewayipv6: fd65:a1a8:60ad:938::2
+  ipAddressCount: 128
+  ipAddresses:
+    - 10.93.251.0
+    - 10.93.251.1
+    - 10.93.251.2
+    - 10.93.251.3
+    - 10.93.251.4
+    - 10.93.251.5
+    - 10.93.251.6
+    - 10.93.251.7
+    - 10.93.251.8
+    - 10.93.251.9
+    - 10.93.251.10
+    - 10.93.251.11
+    - 10.93.251.12
+    - 10.93.251.13
+    - 10.93.251.14
+    - 10.93.251.15
+    - 10.93.251.16
+    - 10.93.251.17
+    - 10.93.251.18
+    - 10.93.251.19
+  ipv6prefix: fd65:a1a8:60ad:938::/64
+  machineNetworkCidr: 10.93.251.0/25
+  netmask: 255.255.255.128
+  podName: dal10.pod03
+  portGroupName: ci-vlan-938
+  primaryRouterHostname: bcr03a.dal10
+  startIPv6Address: fd65:a1a8:60ad:938::4
+  subnetType: SECONDARY_ON_VLAN
+  vlanId: "938"

--- a/test/manifests/network-ci-vlan-958-1-dal10-dal10.pod03-multi-1.yaml
+++ b/test/manifests/network-ci-vlan-958-1-dal10-dal10.pod03-multi-1.yaml
@@ -1,0 +1,29 @@
+apiVersion: vspherecapacitymanager.splat.io/v1
+kind: Network
+metadata:
+  labels:
+    vsphere-capacity-manager.splat-team.io/network-type: multi-tenant
+  name: ci-vlan-958-1-dal10-dal10.pod03-multi-1
+spec:
+  cidr: 25
+  cidrIPv6: 64
+  datacenterName: dal10
+  gateway: 10.93.152.1
+  gatewayipv6: fd65:a1a8:60ad:958::2
+  ipAddressCount: 128
+  ipAddresses:
+    - 10.93.152.2
+    - 10.93.152.3
+    - 10.93.152.4
+    - 10.93.152.5
+  ipv6prefix: fd65:a1a8:60ad:958::/64
+  machineNetworkCidr: 10.93.152.0/25
+  netmask: 255.255.255.128
+  podName: dal10.pod03
+  portGroupName: ci-vlan-958-1
+  primaryRouterHostname: bcr03a.dal10
+  startIPv6Address: fd65:a1a8:60ad:958::4
+  subnetType: SECONDARY_ON_VLAN
+  vlanId: "958"
+
+

--- a/test/manifests/network-ci-vlan-958-1-dal10-dal10.pod03-multi-2.yaml
+++ b/test/manifests/network-ci-vlan-958-1-dal10-dal10.pod03-multi-2.yaml
@@ -1,0 +1,29 @@
+apiVersion: vspherecapacitymanager.splat.io/v1
+kind: Network
+metadata:
+  labels:
+    vsphere-capacity-manager.splat-team.io/network-type: multi-tenant
+  name: ci-vlan-958-1-dal10-dal10.pod03-multi-2
+spec:
+  cidr: 25
+  cidrIPv6: 64
+  datacenterName: dal10
+  gateway: 10.93.152.1
+  gatewayipv6: fd65:a1a8:60ad:958::2
+  ipAddressCount: 128
+  ipAddresses:
+    - 10.93.152.4
+    - 10.93.152.5
+    - 10.93.152.6
+    - 10.93.152.7
+  ipv6prefix: fd65:a1a8:60ad:958::/64
+  machineNetworkCidr: 10.93.152.0/25
+  netmask: 255.255.255.128
+  podName: dal10.pod03
+  portGroupName: ci-vlan-958-2
+  primaryRouterHostname: bcr03a.dal10
+  startIPv6Address: fd65:a1a8:60ad:958::4
+  subnetType: SECONDARY_ON_VLAN
+  vlanId: "958"
+
+

--- a/test/manifests/network-ci-vlan-958-1-dal10-dal10.pod03-multi-3.yaml
+++ b/test/manifests/network-ci-vlan-958-1-dal10-dal10.pod03-multi-3.yaml
@@ -1,0 +1,29 @@
+apiVersion: vspherecapacitymanager.splat.io/v1
+kind: Network
+metadata:
+  labels:
+    vsphere-capacity-manager.splat-team.io/network-type: multi-tenant
+  name: ci-vlan-958-1-dal10-dal10.pod03-multi-3
+spec:
+  cidr: 25
+  cidrIPv6: 64
+  datacenterName: dal10
+  gateway: 10.93.152.1
+  gatewayipv6: fd65:a1a8:60ad:958::2
+  ipAddressCount: 128
+  ipAddresses:
+    - 10.93.152.6
+    - 10.93.152.7
+    - 10.93.152.8
+    - 10.93.152.9
+  ipv6prefix: fd65:a1a8:60ad:958::/64
+  machineNetworkCidr: 10.93.152.0/25
+  netmask: 255.255.255.128
+  podName: dal10.pod03
+  portGroupName: ci-vlan-958-3
+  primaryRouterHostname: bcr03a.dal10
+  startIPv6Address: fd65:a1a8:60ad:958::4
+  subnetType: SECONDARY_ON_VLAN
+  vlanId: "958"
+
+

--- a/test/manifests/network-ci-vlan-958-1-dal10-dal10.pod03.yaml
+++ b/test/manifests/network-ci-vlan-958-1-dal10-dal10.pod03.yaml
@@ -1,0 +1,45 @@
+apiVersion: vspherecapacitymanager.splat.io/v1
+kind: Network
+metadata:
+  labels:
+    vsphere-capacity-manager.splat-team.io/network-type: multi-tenant
+  name: ci-vlan-958-1-dal10-dal10.pod03
+spec:
+  cidr: 25
+  cidrIPv6: 64
+  datacenterName: dal10
+  gateway: 10.93.152.1
+  gatewayipv6: fd65:a1a8:60ad:958::2
+  ipAddressCount: 128
+  ipAddresses:
+    - 10.93.152.0
+    - 10.93.152.1
+    - 10.93.152.2
+    - 10.93.152.3
+    - 10.93.152.4
+    - 10.93.152.5
+    - 10.93.152.6
+    - 10.93.152.7
+    - 10.93.152.8
+    - 10.93.152.9
+    - 10.93.152.10
+    - 10.93.152.11
+    - 10.93.152.12
+    - 10.93.152.13
+    - 10.93.152.14
+    - 10.93.152.15
+    - 10.93.152.16
+    - 10.93.152.17
+    - 10.93.152.18
+    - 10.93.152.19
+  ipv6prefix: fd65:a1a8:60ad:958::/64
+  machineNetworkCidr: 10.93.152.0/25
+  netmask: 255.255.255.128
+  podName: dal10.pod03
+  portGroupName: ci-vlan-958
+  primaryRouterHostname: bcr03a.dal10
+  startIPv6Address: fd65:a1a8:60ad:958::4
+  subnetType: SECONDARY_ON_VLAN
+  vlanId: "958"
+
+

--- a/test/manifests/pool-test.com-IBMCloud-vcs-ci-workload.yaml
+++ b/test/manifests/pool-test.com-IBMCloud-vcs-ci-workload.yaml
@@ -48,7 +48,16 @@ spec:
     - /IBMCloud/network/ci-vlan-1207
     - /IBMCloud/network/ci-vlan-1197
     - /IBMCloud/network/ci-vlan-1148
+    - /IBMCloud/network/ci-vlan-958
+    - /IBMCloud/network/ci-vlan-958-1
+    - /IBMCloud/network/ci-vlan-958-2
+    - /IBMCloud/network/ci-vlan-958-3
     - /IBMCloud/network/ci-vlan-956
+    - /IBMCloud/network/ci-vlan-938
+    - /IBMCloud/network/ci-vlan-938-1
+    - /IBMCloud/network/ci-vlan-938-2
+    - /IBMCloud/network/ci-vlan-938-3
+
   vcpus: 240
   overCommitRatio: "2.5"
   zone: us-east-4a

--- a/test/manifests/pool-test.com-IBMCloud-vcs-mdcnc-workload-1.yaml
+++ b/test/manifests/pool-test.com-IBMCloud-vcs-mdcnc-workload-1.yaml
@@ -50,6 +50,10 @@ spec:
     - /IBMCloud/network/ci-vlan-1232
     - /IBMCloud/network/ci-vlan-1237
     - /IBMCloud/network/ci-vlan-1259
+    - /IBMCloud/network/ci-vlan-938
+    - /IBMCloud/network/ci-vlan-938-1
+    - /IBMCloud/network/ci-vlan-938-2
+    - /IBMCloud/network/ci-vlan-938-3
   vcpus: 32
   zone: us-east-1a
 status:


### PR DESCRIPTION
### Changes
- Added logic to prevent multiple networks with same port group being assigned to single lease.
- Enhanced the delayed logic to look at pools