### PR TITLE
SPLAT-2127: Adjusted delay logic to match network types

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,7 +38,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := (&controller.LeaseReconciler{}).
+	if err := (&controller.LeaseReconciler{
+		// This will be set for now via constant, but might be good in future to make configurable via startup parameter.
+		AllowMultiToUseSingle: controller.ALLOW_MULTI_TO_USE_SINGLE,
+	}).
 		SetupWithManager(mgr); err != nil {
 		log.Printf("unable to create controller: %v", err)
 		os.Exit(1)

--- a/test/leases_test.go
+++ b/test/leases_test.go
@@ -48,10 +48,11 @@ var _ = Describe("Lease management", func() {
 		Expect(err).ToNot(HaveOccurred(), "Manager should be able to be created")
 
 		leaseReconciler := &controller.LeaseReconciler{
-			Client:         mgr.GetClient(),
-			UncachedClient: mgr.GetClient(),
-			Namespace:      namespaceName,
-			OperatorName:   controllerName,
+			Client:                mgr.GetClient(),
+			UncachedClient:        mgr.GetClient(),
+			Namespace:             namespaceName,
+			OperatorName:          controllerName,
+			AllowMultiToUseSingle: false, // TODO: This should be set via each test
 		}
 		Expect(leaseReconciler.SetupWithManager(mgr)).To(Succeed(), "Reconciler should be able to setup with manager")
 


### PR DESCRIPTION
SPLAT-2127

### Changes
- Added boolean to configure if multi-tenant leases can use single-tenant networks
- Enhanced delay logic to only compare leases of same networkType