### PR TITLE
SPLAT-2246: Added logging to include job-name at start of processing lease

### DIFF
--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	BoskosIdLabel             = "boskos-lease-id"
+	JobNameLabel              = "job-name"
 	ALLOW_MULTI_TO_USE_SINGLE = false
 )
 
@@ -479,6 +480,7 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// TODO: How often are we hitting this and can we remove this and just use the one above?
 	if len(lease.Status.Phase) == 0 {
+		log.Printf("setting lease %s status to %s", lease.Name, v1.PHASE_PENDING)
 		lease.Status.Phase = v1.PHASE_PENDING
 
 		conditions.Set(lease, conditions.FalseCondition(
@@ -493,9 +495,13 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		conditions.Set(lease, conditions.FalseCondition(
 			v1.LeaseConditionTypePartial,
 		))
-	} else {
-		log.Printf("processing lease %v with Phase %v", lease.Name, lease.Status.Phase)
 	}
+
+	jobName, exists := lease.Labels[JobNameLabel]
+	if !exists {
+		jobName = "Unknown Job"
+	}
+	log.Printf("processing lease %v [%v] with Phase %v", lease.Name, jobName, lease.Status.Phase)
 
 	// Set default network type
 	if len(lease.Spec.NetworkType) == 0 {


### PR DESCRIPTION
[SPLAT-2245](https://issues.redhat.com//browse/SPLAT-2245)

### Changes
- Updated logging for initial processing of a lease to include the job-name to improve debugging when trying to determine what job has left leases around after completion / abortion.

### Notes
Example output:
`2025/05/29 10:43:43 processing lease lease1 [TestLeaase] with Phase Pending
`