### PR TITLE
SPLAT-2252: Added usage of job url for debugging

### DIFF
--- a/config/crd/bases/vspherecapacitymanager.splat.io_leases.yaml
+++ b/config/crd/bases/vspherecapacitymanager.splat.io_leases.yaml
@@ -143,6 +143,10 @@ spec:
                 description: EnvVars a freeform string which contains bash which is
                   to be sourced by the holder of the lease.
                 type: string
+              job-link:
+                description: JobLink defines a link to the job that owns this lease.  Its
+                  primarily used when debugging issues w/ lease management.
+                type: string
               name:
                 description: name defines the arbitrary but unique name of a failure
                   domain.

--- a/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types.go
+++ b/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types.go
@@ -83,6 +83,9 @@ type LeaseStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []Condition `json:"conditions,omitempty"`
+
+	// JobLink defines a link to the job that owns this lease.  Its primarily used when debugging issues w/ lease management.
+	JobLink string `json:"job-link,omitempty"`
 }
 
 type Leases []*Lease

--- a/pkg/controller/namespaces.go
+++ b/pkg/controller/namespaces.go
@@ -72,6 +72,7 @@ func (l *NamespaceReconciler) PruneAbandonedLeases(ctx context.Context) {
 			for _, ns := range namespaces.Items {
 				if ns.Name == leaseNs {
 					nsFound = true
+					break
 				}
 			}
 			if nsFound {


### PR DESCRIPTION
[SPLAT-2252](https://issues.redhat.com//browse/SPLAT-2252)

### Changes
- Added logic to set job url into status of lease
- Added logging to record the job url for debugging purposes