### PR TITLE
SPLAT-2460: Rename nameserver field to be nameservers

### DIFF
--- a/config/crd/bases/vspherecapacitymanager.splat.io_networks.yaml
+++ b/config/crd/bases/vspherecapacitymanager.splat.io_networks.yaml
@@ -76,8 +76,8 @@ spec:
               machineNetworkCidr:
                 description: MachineNetworkCidr represents the machine network CIDR.
                 type: string
-              nameserver:
-                description: Nameserver the nameserver
+              nameservers:
+                description: Nameservers an array of the nameservers to use
                 items:
                   type: string
                 type: array

--- a/pkg/apis/vspherecapacitymanager.splat.io/v1/network_types.go
+++ b/pkg/apis/vspherecapacitymanager.splat.io/v1/network_types.go
@@ -86,9 +86,9 @@ type NetworkSpec struct {
 	// +optional
 	PrimaryRouterHostname string `json:"primaryRouterHostname"`
 
-	// Nameserver the nameserver
+	// Nameservers an array of the nameservers to use
 	// +optional
-	Nameserver []string `json:"nameserver"`
+	Nameservers []string `json:"nameservers"`
 }
 
 // NetworkStatus defines the status for a pool

--- a/pkg/apis/vspherecapacitymanager.splat.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/vspherecapacitymanager.splat.io/v1/zz_generated.deepcopy.go
@@ -280,8 +280,8 @@ func (in *NetworkSpec) DeepCopyInto(out *NetworkSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.Nameserver != nil {
-		in, out := &in.Nameserver, &out.Nameserver
+	if in.Nameservers != nil {
+		in, out := &in.Nameservers, &out.Nameservers
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}


### PR DESCRIPTION
[SPLAT-2460](https://issues.redhat.com//browse/SPLAT-2460)

Changes
Added new nameserver field to network type